### PR TITLE
Fixed acholt-cookbooks/mediawiki_backup#4

### DIFF
--- a/templates/default/mediawiki-backup.erb
+++ b/templates/default/mediawiki-backup.erb
@@ -51,7 +51,7 @@ SSLCERTS='<%= node['mediawiki_backup']['ssl_certs'].join(' ') %>'
 
 
 function ERROR {
-  echo "Backup Failed"
+  echo "Backup Failed" | $LOGGER
   SETRW
   CLEANUP
   exit 1;


### PR DESCRIPTION
-Fix if script errors out it will log it to the system log not stdout.
